### PR TITLE
Redução de Binário

### DIFF
--- a/grow.php/wandersonwhcr/Dockerfile
+++ b/grow.php/wandersonwhcr/Dockerfile
@@ -17,6 +17,9 @@ RUN ./configure --disable-all --disable-cgi --disable-phpdbg --disable-debug CFL
 RUN make \
     && make install
 
+RUN apk add upx \
+    && upx -9 /usr/local/bin/php
+
 FROM scratch
 
 COPY --from=builder /usr/local/bin/php /usr/local/bin/php


### PR DESCRIPTION
Este PR compacta o binário do PHP CLI deixando a imagem final com 2,85MB.

Próximo passo será a construção da API.