### PR TITLE
Aprimora Compactação do Binário do PHP

### DIFF
--- a/grow.php/wandersonwhcr/Base.Dockerfile
+++ b/grow.php/wandersonwhcr/Base.Dockerfile
@@ -20,7 +20,11 @@ RUN apk add alpine-sdk autoconf automake libtool \
     && apk add bison re2c \
     && ./buildconf --force
 
-RUN ./configure --disable-all --disable-cgi --disable-phpdbg --disable-debug --enable-apcu CFLAGS="-O3 -march=native"
+RUN ./configure --disable-all \
+        --disable-cgi \
+        --disable-phpdbg --disable-debug \
+        --enable-apcu \
+        CFLAGS="-O3 -march=native"
 
 RUN make \
     && make install

--- a/grow.php/wandersonwhcr/Base.Dockerfile
+++ b/grow.php/wandersonwhcr/Base.Dockerfile
@@ -25,6 +25,7 @@ RUN ./configure --disable-all \
         --disable-phpdbg --disable-debug \
         --enable-apcu \
         CFLAGS="-O3 -march=native" \
+        CPPFLAGS="-O3 -march=native" \
     && sed -i 's/-export-dynamic/-all-static/g' Makefile
 
 RUN make \

--- a/grow.php/wandersonwhcr/Base.Dockerfile
+++ b/grow.php/wandersonwhcr/Base.Dockerfile
@@ -24,7 +24,8 @@ RUN ./configure --disable-all \
         --disable-cgi \
         --disable-phpdbg --disable-debug \
         --enable-apcu \
-        CFLAGS="-O3 -march=native"
+        CFLAGS="-O3 -march=native" \
+    && sed -i 's/-export-dynamic/-all-static/g' Makefile
 
 RUN make \
     && make install

--- a/grow.php/wandersonwhcr/Dockerfile
+++ b/grow.php/wandersonwhcr/Dockerfile
@@ -8,7 +8,6 @@ RUN apk add upx \
 FROM scratch
 
 COPY --from=base /usr/local/bin/php /usr/local/bin/php
-COPY --from=base /lib/ld-musl-x86_64.so.1 /lib/ld-musl-x86_64.so.1
 
 COPY ./php.ini /usr/local/lib/php.ini
 

--- a/grow.php/wandersonwhcr/README.md
+++ b/grow.php/wandersonwhcr/README.md
@@ -1,6 +1,6 @@
 # grow.php/wandersonwhcr
 
-* Tamanho da Imagem: `2.75MB`
+* Tamanho da Imagem: `2.38MB`
 
 ## Imagem
 


### PR DESCRIPTION
Este PR modifica a construção da imagem Docker do PHP e compila o SAPI `cli` de forma estática, fazendo com que a biblioteca MUSL seja incluida e compactada pelo `upx`.

Isso faz com que a imagem seja reduzida de `2.75MB` para `2.38MB`.